### PR TITLE
Add datasette-dashboards to plugin repos list

### DIFF
--- a/plugin_repos.yml
+++ b/plugin_repos.yml
@@ -70,3 +70,4 @@
 - simonw/datasette-x-forwarded-host
 - simonw/datasette-verify
 - simonw/datasette-template-request
+- rclement/datasette-dashboards


### PR DESCRIPTION
Add the `datasette-dashboards` plugin from `rclement/datasette-dashboards` in Datasette plugin repositories list.